### PR TITLE
Restore possibility to add '--ignore' flag

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -115,7 +115,6 @@ advise users to use the `~/.config/flake8` config file.
 
     - Decprecated options:
       - `g:flake8_builtins`
-      - `g:flake8_ignore`
       - `g:flake8_max_line_length`
       - `g:flake8_max_complexity`
 

--- a/autoload/flake8.vim
+++ b/autoload/flake8.vim
@@ -32,7 +32,7 @@ function s:Warnings()
     let l:show_website_url = 0
 
     let l:msg = "has been deprecated in favour of flake8 config files"
-    for setting_name in ['g:flake8_ignore', 'g:flake8_builtins', 'g:flake8_max_line_length', 'g:flake8_max_complexity']
+    for setting_name in ['g:flake8_builtins', 'g:flake8_max_line_length', 'g:flake8_max_complexity']
       if exists(setting_name)
         echohl WarningMsg | echom setting_name l:msg | echohl None
         let l:show_website_url = 1
@@ -71,6 +71,8 @@ function! s:Setup()  " {{{
 
     " flake8 command
     call s:DeclareOption('flake8_cmd', '', '"flake8"')
+    " ignore
+    call s:DeclareOption('flake8_ignore', ' --ignore=', '')
     " quickfix
     call s:DeclareOption('flake8_quickfix_location', '', '"belowright"')
     call s:DeclareOption('flake8_quickfix_height', '', 5)
@@ -137,7 +139,7 @@ function! s:Flake8()  " {{{
 
     " perform the grep itself
     let &grepformat="%f:%l:%c: %m\,%f:%l: %m"
-    let &grepprg=s:flake8_cmd
+    let &grepprg=s:flake8_cmd.s:flake8_ignore
     silent! grep! "%"
 
     " restore grep settings


### PR DESCRIPTION
Because not all using config for flake8, but it can be possible just add:

```
autocmd BufWritePost *.py call Flake8()
let g:flake8_ignore='E501'
```
